### PR TITLE
Enhance script handling and serialization support

### DIFF
--- a/src/Core/Resources/ResourceManager.cpp
+++ b/src/Core/Resources/ResourceManager.cpp
@@ -192,6 +192,21 @@ Script* ResourceManager::GetScript(const std::string& resourceId)
     return nullptr;
 }
 
+Script* ResourceManager::GetScript(const std::string& className, const std::string& assemblyName)
+{
+    for (auto& [resourceId, script] : m_scripts)
+    {
+        if (script != nullptr && 
+            script->GetClassName() == className && 
+            script->GetAssemblyName() == assemblyName)
+        {
+            return script;
+        }
+    }
+
+    return nullptr;
+}
+
 UiContent* ResourceManager::GetUiContent(const std::string& resourceId)
 {
     auto it = m_uiContents.find(resourceId);

--- a/src/Core/Resources/ResourceManager.h
+++ b/src/Core/Resources/ResourceManager.h
@@ -46,6 +46,7 @@ class CORE_API ResourceManager
     Texture* GetTexture(const std::string& resourceId);
     Mesh* GetMesh(const std::string& resourceId);
     Script* GetScript(const std::string& resourceId);
+    Script* GetScript(const std::string& className, const std::string& assemblyName);
     UiContent* GetUiContent(const std::string& resourceId);
     Font* GetFont(const std::string& resourceId);
     std::map<std::string, Shader*>& GetShaders();

--- a/src/Core/Scripting/ScriptEventHandler.h
+++ b/src/Core/Scripting/ScriptEventHandler.h
@@ -11,7 +11,7 @@ public:
     static void QueueEvent(uint32_t eventId);
     static void Process();
    private:
- static std::queue<uint32_t> m_sEventIds;
+    static std::queue<uint32_t> m_sEventIds;
 };
 }  // namespace DreamEngine::Core::Scripting
 #endif

--- a/src/Editor/Controllers/SceneController.cpp
+++ b/src/Editor/Controllers/SceneController.cpp
@@ -131,7 +131,11 @@ bool SceneController::SaveSceneData(EntityManager* entityManager)
             entityConfig.components.material.resourceId = material.material->resourceId;
 
         if (const ScriptComponent& script = entity->GetComponent<ScriptComponent>(); script.has && script.script != nullptr)
+        {
             entityConfig.components.script.resourceId = script.script->resourceId;
+            entityConfig.components.script.assemblyName = script.script->GetAssemblyName();
+            entityConfig.components.script.className = script.script->GetClassName();
+        }
 
         if (const CameraComponent& camera = entity->GetComponent<CameraComponent>(); camera.has)
         {
@@ -262,7 +266,7 @@ void SceneController::LoadScene(EntityManager* entityManager)
         scene->SetMainCameraEntity(mainCameraEntity);
 }
 
-vector<Entity*> SceneController::CreateEntities(EntityManager* entityManager, SceneData* sceneData)
+vector<Entity*> SceneController::CreateEntities(EntityManager* entityManager, DreamEngine::Editor::Models::Datas::SceneData* sceneData)
 {
     vector<Entity*> entities;
 
@@ -292,11 +296,16 @@ vector<Entity*> SceneController::CreateEntities(EntityManager* entityManager, Sc
             materialComponent.has = true;
         }
 
-        if (!entityConfig.components.script.resourceId.empty())
+        if (!entityConfig.components.script.className.empty() && !entityConfig.components.script.assemblyName.empty())
         {
             ScriptComponent& scriptComponent = entity->GetComponent<ScriptComponent>();
-            scriptComponent.script = ResourceManager::Instance().GetScript(entityConfig.components.script.resourceId);
-            scriptComponent.has = true;
+            scriptComponent.script = ResourceManager::Instance().GetScript(
+                entityConfig.components.script.className,
+                entityConfig.components.script.assemblyName
+            );
+            
+            if (scriptComponent.script != nullptr)
+                scriptComponent.has = true;
         }
 
         if (entityConfig.components.camera.has)
@@ -322,7 +331,7 @@ vector<Entity*> SceneController::CreateEntities(EntityManager* entityManager, Sc
     return entities;
 }
 
-void SceneController::SetParentAndChildren(const SceneData* sceneData, Entity*& mainCameraEntity, vector<Entity*> entities)
+void SceneController::SetParentAndChildren(const DreamEngine::Editor::Models::Datas::SceneData* sceneData, Entity*& mainCameraEntity, vector<Entity*> entities)
 {
     for (auto& entityConfig : sceneData->entities)
     {

--- a/src/Editor/Models/Datas/Components/ScriptComponentData.h
+++ b/src/Editor/Models/Datas/Components/ScriptComponentData.h
@@ -8,6 +8,8 @@ namespace DreamEngine::Editor::Models::Datas::Components
 struct ScriptComponentData
 {
     std::string resourceId;
+    std::string className;
+    std::string assemblyName;
 };
 
 }  // namespace DreamEngine::Editor::Models::Datas::Components

--- a/src/Editor/Serializers/SceneDataSerializer.cpp
+++ b/src/Editor/Serializers/SceneDataSerializer.cpp
@@ -15,7 +15,7 @@ using namespace DreamEngine::Core::GameSystem;
 using namespace DreamEngine::Core::ECS::Components;
 using json = nlohmann::json;
 
-std::string SceneDataSerializer::Serialize(SceneData& sceneData)
+std::string SceneDataSerializer::Serialize(DreamEngine::Editor::Models::Datas::SceneData& sceneData)
 {
     json j;
 
@@ -136,7 +136,11 @@ Datas::SceneData& SceneDataSerializer::Deserialize(std::ifstream& stream)
                 jsonComponent["material"]["resourceId"].get_to(e.components.material.resourceId);
 
             if (jsonComponent.find("script") != jsonComponent.end())
+            {
                 jsonComponent["script"]["resourceId"].get_to(e.components.script.resourceId);
+                jsonComponent["script"]["className"].get_to(e.components.script.className);
+                jsonComponent["script"]["assemblyName"].get_to(e.components.script.assemblyName);
+            }
 
             if (jsonComponent.find("parent") != jsonComponent.end())
                 jsonComponent["parent"]["parentIdentifier"].get_to(e.components.parent.parentIdentifier);
@@ -206,7 +210,11 @@ json SceneDataSerializer::Serialize(EntityConfigData& entityConfig)
 
     // script
     if (!entityConfig.components.script.resourceId.empty())
+    {
         jsonEntity["components"]["script"]["resourceId"] = entityConfig.components.script.resourceId;
+        jsonEntity["components"]["script"]["className"] = entityConfig.components.script.className;
+        jsonEntity["components"]["script"]["assemblyName"] = entityConfig.components.script.assemblyName;
+    }
 
     // camera
     if (entityConfig.components.camera.has)


### PR DESCRIPTION
Added a new overload for `ResourceManager::GetScript` to retrieve scripts by `className` and `assemblyName`. Updated `ScriptComponentData` to include `className` and `assemblyName` fields for better script identification.

Modified `SceneController` methods to use the new `GetScript` overload and ensure proper handling of script metadata during entity creation and scene saving. Updated `SceneDataSerializer` to serialize and deserialize the new script fields.

Refactored method signatures to use fully qualified namespaces for clarity. Made minor formatting changes in `ScriptEventHandler`. Improved overall script handling and serialization consistency.