### PR TITLE
Refactor: centralize texture loading via TextureImporter

### DIFF
--- a/src/Editor/Assets/Shaders/default.frag.glsl
+++ b/src/Editor/Assets/Shaders/default.frag.glsl
@@ -27,16 +27,25 @@ uniform sampler2D texture_diffuse1;
 
 void main()
 {
-    // ambient
-    vec3 ambient = light.ambient * material.ambient;
+    // 1. Displays the submitted texture
+    vec4 texElement = texture(texture_diffuse1, TexCoords);
+    
+    // 2. If the texture is the neutral white one (or if the model lacks an actual diffuse texture),
+    // multiplying by material.diffuse preserves the editor color.
+    // If it is an actual colored texture, it will blend with the material's base color.
+    vec3 baseDiffuse = material.diffuse * texElement.rgb;
+    vec3 baseAmbient = material.ambient * texElement.rgb;
+
+    // ambient (Illuminates the calculated color with ambient light)
+    vec3 ambient = light.ambient * baseAmbient;
   	
-    // diffuse 
+    // diffuse (Applies diffuse light to the combined color)
     vec3 norm = normalize(Normal);
     vec3 lightDir = normalize(light.position - FragPos);
     float diff = max(dot(norm, lightDir), 0.0);
-    vec3 diffuse = light.diffuse * (diff * material.diffuse);
+    vec3 diffuse = light.diffuse * (diff * baseDiffuse);
     
-    // specular
+    // specular (Retains the material's original sheen)
     vec3 viewDir = normalize(viewPos - FragPos);
     vec3 reflectDir = reflect(-lightDir, norm);  
     float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
@@ -44,6 +53,4 @@ void main()
         
     vec3 result = ambient + diffuse + specular;
     FragColor = vec4(result, 1.0);
-
-    //FragColor = texture(texture_diffuse1, TexCoords);
 } 

--- a/src/Editor/CMakeLists.txt
+++ b/src/Editor/CMakeLists.txt
@@ -38,6 +38,8 @@ add_executable(Editor
     Importers/BaseModelImporter.h
     Importers/AssimpModelImporter.h
     Importers/AssimpModelImporter.cpp
+    Importers/TextureImporter.h
+    Importers/TextureImporter.cpp
 
     Loggers/EditorLogger.h
     Loggers/EditorLogger.cpp

--- a/src/Editor/Controllers/ResourceController.cpp
+++ b/src/Editor/Controllers/ResourceController.cpp
@@ -17,12 +17,14 @@
 #include "../Serializers/SceneDataSerializer.h"
 #include "../Helpers/FileHelper.h"
 #include <ECS/Components/UiComponent.h>
+#include "../Importers/TextureImporter.h"
 
 using namespace DreamEngine::Core::Loggers;
 using namespace DreamEngine::Core::ECS::Components;
 using namespace DreamEngine::Editor::Controllers;
 using namespace DreamEngine::Editor::Serializers;
 using namespace DreamEngine::Editor::Helpers;
+using namespace DreamEngine::Editor::Importers;
 
 ResourceController::ResourceController(EditorContext& editorContext) 
     : m_editorContext(editorContext)
@@ -459,7 +461,8 @@ void ResourceController::LoadModels(const std::vector<std::string>& modelFiles)
 
                 if (textureFromResourceManager == nullptr)
                 {
-                    textureFromResourceManager = new Texture(*texture);
+                    textureFromResourceManager = TextureImporter::Import(texture->path, texture->name.c_str(), texture->type);
+                    textureFromResourceManager->resourceId = texture->resourceId;
                     TryAddToResourceManager(textureFromResourceManager, false);
                 }
 

--- a/src/Editor/Importers/AssimpModelImporter.cpp
+++ b/src/Editor/Importers/AssimpModelImporter.cpp
@@ -12,6 +12,7 @@
 #include "../Vendors/stb_image.h"
 #include "Loggers/LoggerSingleton.h"
 #include "Render/OpenGL/OpenGLMesh.h"
+#include "TextureImporter.h"
 
 using namespace DreamEngine::Editor::Importers;
 using namespace DreamEngine::Core;
@@ -170,20 +171,13 @@ std::vector<Texture*> AssimpModelImporter::LoadMaterialTextures(aiMaterial* mat,
         if (std::ranges::find(m_texturePaths, path) != m_texturePaths.end())
             continue;
 
-        int width, height, nrComponents;
-        unsigned char* data = stbi_load(path.c_str(), &width, &height, &nrComponents, 0);
+        Texture* texture = TextureImporter::Import(path, pathFromAssimp.C_Str(), textureType);
 
-        if (data != nullptr)
+        if (texture != nullptr)
         {
-            Texture* texture = Application::Instance().GetRenderAPI()->CreateTexture(data, width, height, nrComponents);
-            texture->type = textureType;
-            texture->name = pathFromAssimp.C_Str();
-            texture->path = path;
             textures.push_back(texture);
             m_model.textures.push_back(texture);
             m_texturePaths.emplace_back(path);
-
-            stbi_image_free(data);
         }
         else
             LoggerSingleton::Instance().LogWarning("AssimpModelImporter::LoadMaterialTextures -> Failed to load texture from path: " + m_path +

--- a/src/Editor/Importers/TextureImporter.cpp
+++ b/src/Editor/Importers/TextureImporter.cpp
@@ -1,0 +1,29 @@
+#include "TextureImporter.h"
+
+#include "Application.h"
+#include "../Vendors/stb_image.h"
+
+using namespace DreamEngine;
+using namespace DreamEngine::Core;
+using namespace DreamEngine::Core::Render;
+using namespace DreamEngine::Editor;
+using namespace DreamEngine::Editor::Importers;
+
+Texture* TextureImporter::Import(std::string const& path, const char* fileName, TextureType& textureType)
+{
+    Texture* texture = nullptr;
+    int width, height, nrComponents;
+    unsigned char* data = stbi_load(path.c_str(), &width, &height, &nrComponents, 0);
+
+    if (data != nullptr)
+    {
+        texture = Application::Instance().GetRenderAPI()->CreateTexture(data, width, height, nrComponents);
+        texture->type = textureType;
+        texture->name = fileName;
+        texture->path = path;
+
+        stbi_image_free(data);
+    }
+
+    return texture;
+}

--- a/src/Editor/Importers/TextureImporter.h
+++ b/src/Editor/Importers/TextureImporter.h
@@ -1,0 +1,18 @@
+#ifndef EDITOR_IMPORTERS_TEXTURE_IMPORTER_H_
+#define EDITOR_IMPORTERS_TEXTURE_IMPORTER_H_
+
+#include <string>
+#include "../../Core/Render/Texture.h"
+#include "../../Core/Render/TextureType.h"
+
+namespace DreamEngine::Editor::Importers
+{
+    using namespace DreamEngine::Core::Render;
+class TextureImporter
+{
+   public:
+    static Texture* Import(std::string const& path, const char* fileName, TextureType& textureType);
+};
+
+}  // namespace DreamEngine::Editor::Importers
+#endif


### PR DESCRIPTION
Introduce TextureImporter utility to unify texture loading logic. Update fragment shader to blend material and texture colors. Refactor ResourceController and AssimpModelImporter to use TextureImporter::Import. Add TextureImporter to CMakeLists.txt and update relevant includes. Improves code reuse and consistency.